### PR TITLE
fix: json enum value conversion

### DIFF
--- a/Kulipa.Sdk.Tests/Unit/Resources/CardsResourceTests.cs
+++ b/Kulipa.Sdk.Tests/Unit/Resources/CardsResourceTests.cs
@@ -47,7 +47,7 @@ namespace Kulipa.Sdk.Tests.Unit.Resources
             // Arrange
             var request = new CreateCardRequest
             {
-                Format = CardFormat.Virtual,
+                Type = CardType.Virtual,
                 UserId = "usr-123e4567-e89b-12d3-a456-426614174000",
                 Tier = CardTier.Standard,
                 CurrencyCode = "USD"
@@ -57,7 +57,7 @@ namespace Kulipa.Sdk.Tests.Unit.Resources
             {
                 Id = "crd-987f6543-e21b-43d2-b123-426614174111",
                 UserId = request.UserId,
-                Format = CardFormat.Virtual,
+                Type = CardType.Virtual,
                 Status = CardStatus.Active,
                 LastFourDigits = "1234",
                 CreatedAt = DateTime.UtcNow,
@@ -90,7 +90,7 @@ namespace Kulipa.Sdk.Tests.Unit.Resources
             result.Should().NotBeNull();
             result.Id.Should().Be(expectedCard.Id);
             result.UserId.Should().Be(expectedCard.UserId);
-            result.Format.Should().Be(expectedCard.Format);
+            result.Type.Should().Be(expectedCard.Type);
             result.LastFourDigits.Should().Be(expectedCard.LastFourDigits);
         }
 
@@ -107,7 +107,7 @@ namespace Kulipa.Sdk.Tests.Unit.Resources
             // Arrange
             var request = new CreateCardRequest
             {
-                Format = CardFormat.Physical,
+                Type = CardType.Physical,
                 UserId = "usr-123e4567-e89b-12d3-a456-426614174000",
                 Tier = CardTier.Premium,
                 DeliveryType = DeliveryType.ShipToUser
@@ -155,7 +155,7 @@ namespace Kulipa.Sdk.Tests.Unit.Resources
             // Arrange
             var request = new CreateCardRequest
             {
-                Format = CardFormat.Virtual,
+                Type = CardType.Virtual,
                 UserId = "usr-123e4567-e89b-12d3-a456-426614174000",
                 Tier = CardTier.Standard
             };
@@ -190,7 +190,7 @@ namespace Kulipa.Sdk.Tests.Unit.Resources
             // Arrange
             var request = new CreateCardRequest
             {
-                Format = CardFormat.Virtual,
+                Type = CardType.Virtual,
                 UserId = "usr-123",
                 Tier = CardTier.Standard
             };
@@ -464,7 +464,7 @@ namespace Kulipa.Sdk.Tests.Unit.Resources
                 // Arrange
                 var request = new CreateCardRequest
                 {
-                    Format = CardFormat.Virtual,
+                    Type = CardType.Virtual,
                     UserId = "usr-123",
                     Tier = CardTier.Standard
                 };

--- a/Kulipa.Sdk/JsonConverters/KebabCaseLowerJsonStringEnumConverter.cs
+++ b/Kulipa.Sdk/JsonConverters/KebabCaseLowerJsonStringEnumConverter.cs
@@ -1,0 +1,10 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Kulipa.Sdk.JsonConverters
+{
+    /// <summary>
+    ///     A JSON converter for enumerations that serializes enum values as kebab_case lowercase strings.
+    /// </summary>
+    public class KebabCaseLowerJsonStringEnumConverter() : JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower);
+}

--- a/Kulipa.Sdk/JsonConverters/SnakeCaseLowerJsonStringEnumConverter.cs
+++ b/Kulipa.Sdk/JsonConverters/SnakeCaseLowerJsonStringEnumConverter.cs
@@ -1,0 +1,10 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Kulipa.Sdk.JsonConverters
+{
+    /// <summary>
+    ///     A JSON converter for enumerations that serializes enum values as snake_case lowercase strings.
+    /// </summary>
+    public class SnakeCaseLowerJsonStringEnumConverter() : JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower);
+}

--- a/Kulipa.Sdk/Models/Enums/CardFormat.cs
+++ b/Kulipa.Sdk/Models/Enums/CardFormat.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Kulipa.Sdk.Models.Enums
 {
     /// <summary>
@@ -10,11 +8,11 @@ namespace Kulipa.Sdk.Models.Enums
         /// <summary>
         ///     Physical card that can be shipped to the user.
         /// </summary>
-        [JsonPropertyName("physical")] Physical,
+        Physical,
 
         /// <summary>
         ///     Virtual card that exists only digitally.
         /// </summary>
-        [JsonPropertyName("virtual")] Virtual
+        Virtual
     }
 }

--- a/Kulipa.Sdk/Models/Enums/CardStatus.cs
+++ b/Kulipa.Sdk/Models/Enums/CardStatus.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Kulipa.Sdk.Models.Enums
 {
     /// <summary>
@@ -10,36 +8,36 @@ namespace Kulipa.Sdk.Models.Enums
         /// <summary>
         ///     Card is inactive.
         /// </summary>
-        [JsonPropertyName("inactive")] Inactive,
+        Inactive,
 
         /// <summary>
         ///     Card is active and can be used for transactions.
         /// </summary>
-        [JsonPropertyName("active")] Active,
+        Active,
 
         /// <summary>
         ///     Card has been cancelled.
         /// </summary>
-        [JsonPropertyName("cancelled")] Cancelled,
+        Cancelled,
 
         /// <summary>
         ///     Card is temporarily frozen and cannot be used.
         /// </summary>
-        [JsonPropertyName("frozen")] Frozen,
+        Frozen,
 
         /// <summary>
         ///     Card has been reported as lost.
         /// </summary>
-        [JsonPropertyName("lost")] Lost,
+        Lost,
 
         /// <summary>
         ///     Card has been reported as stolen.
         /// </summary>
-        [JsonPropertyName("stolen")] Stolen,
+        Stolen,
 
         /// <summary>
         ///     Card has expired and is no longer valid.
         /// </summary>
-        [JsonPropertyName("expired")] Expired
+        Expired
     }
 }

--- a/Kulipa.Sdk/Models/Enums/CardTier.cs
+++ b/Kulipa.Sdk/Models/Enums/CardTier.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Kulipa.Sdk.Models.Enums
 {
     /// <summary>
@@ -10,11 +8,11 @@ namespace Kulipa.Sdk.Models.Enums
         /// <summary>
         ///     Standard tier card with basic features.
         /// </summary>
-        [JsonPropertyName("standard")] Standard,
+        Standard,
 
         /// <summary>
         ///     Premium tier card with enhanced features and benefits.
         /// </summary>
-        [JsonPropertyName("premium")] Premium
+        Premium
     }
 }

--- a/Kulipa.Sdk/Models/Enums/CardType.cs
+++ b/Kulipa.Sdk/Models/Enums/CardType.cs
@@ -3,7 +3,7 @@ namespace Kulipa.Sdk.Models.Enums
     /// <summary>
     ///     Represents the physical form factor of a card.
     /// </summary>
-    public enum CardFormat
+    public enum CardType
     {
         /// <summary>
         ///     Physical card that can be shipped to the user.

--- a/Kulipa.Sdk/Models/Enums/DeliveryType.cs
+++ b/Kulipa.Sdk/Models/Enums/DeliveryType.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Kulipa.Sdk.Models.Enums
 {
     /// <summary>
@@ -10,6 +8,6 @@ namespace Kulipa.Sdk.Models.Enums
         /// <summary>
         ///     Card will be shipped directly to the user's address.
         /// </summary>
-        [JsonPropertyName("ship_to_user")] ShipToUser
+        ShipToUser
     }
 }

--- a/Kulipa.Sdk/Models/Enums/FrozenBy.cs
+++ b/Kulipa.Sdk/Models/Enums/FrozenBy.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Kulipa.Sdk.Models.Enums
 {
     /// <summary>
@@ -10,11 +8,11 @@ namespace Kulipa.Sdk.Models.Enums
         /// <summary>
         ///     Card was frozen by the user.
         /// </summary>
-        [JsonPropertyName("user")] User,
+        User,
 
         /// <summary>
         ///     Card was frozen by Kulipa (administrative action).
         /// </summary>
-        [JsonPropertyName("kulipa")] Kulipa
+        Kulipa
     }
 }

--- a/Kulipa.Sdk/Models/Enums/ReissueReason.cs
+++ b/Kulipa.Sdk/Models/Enums/ReissueReason.cs
@@ -1,6 +1,4 @@
-using System.Text.Json.Serialization;
-
-namespace Kulipa.Sdk.Models.Requests.Cards
+namespace Kulipa.Sdk.Models.Enums
 {
     /// <summary>
     ///     Represents the reason for reissuing a card.
@@ -10,16 +8,16 @@ namespace Kulipa.Sdk.Models.Requests.Cards
         /// <summary>
         ///     Card was lost.
         /// </summary>
-        [JsonPropertyName("lost")] Lost,
+        Lost,
 
         /// <summary>
         ///     Card was stolen from the user.
         /// </summary>
-        [JsonPropertyName("stolen")] Stolen,
+        Stolen,
 
         /// <summary>
         ///     Card has expired and needs replacement.
         /// </summary>
-        [JsonPropertyName("expired")] Expired
+        Expired
     }
 }

--- a/Kulipa.Sdk/Models/Enums/TopUpStatus.cs
+++ b/Kulipa.Sdk/Models/Enums/TopUpStatus.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Kulipa.Sdk.Models.Enums
 {
     /// <summary>
@@ -10,11 +8,11 @@ namespace Kulipa.Sdk.Models.Enums
         /// <summary>
         ///     The top-up transaction has been confirmed and successfully processed.
         /// </summary>
-        [JsonPropertyName("confirmed")] Confirmed,
+        Confirmed,
 
         /// <summary>
         ///     The top-up transaction has failed and was not processed.
         /// </summary>
-        [JsonPropertyName("failed")] Failed
+        Failed
     }
 }

--- a/Kulipa.Sdk/Models/Requests/Cards/CreateCardRequest.cs
+++ b/Kulipa.Sdk/Models/Requests/Cards/CreateCardRequest.cs
@@ -15,7 +15,7 @@ namespace Kulipa.Sdk.Models.Requests.Cards
         /// </summary>
         [Required]
         [JsonPropertyName("type")]
-        public CardFormat Format { get; init; }
+        public CardType Type { get; init; }
 
         /// <summary>
         ///     User identifier. Begins with 'usr-' followed by a v4 UUID.

--- a/Kulipa.Sdk/Models/Requests/Cards/CreateCardRequest.cs
+++ b/Kulipa.Sdk/Models/Requests/Cards/CreateCardRequest.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Kulipa.Sdk.JsonConverters;
 using Kulipa.Sdk.Models.Enums;
 
 namespace Kulipa.Sdk.Models.Requests.Cards
@@ -14,7 +15,6 @@ namespace Kulipa.Sdk.Models.Requests.Cards
         /// </summary>
         [Required]
         [JsonPropertyName("type")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardFormat Format { get; init; }
 
         /// <summary>
@@ -35,7 +35,6 @@ namespace Kulipa.Sdk.Models.Requests.Cards
         ///     Card tier.
         /// </summary>
         [JsonPropertyName("tier")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardTier Tier { get; init; } = CardTier.Standard;
 
         /// <summary>
@@ -54,7 +53,7 @@ namespace Kulipa.Sdk.Models.Requests.Cards
         ///     Delivery type for physical cards (do not set for virtual cards).
         /// </summary>
         [JsonPropertyName("deliveryType")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonConverter(typeof(SnakeCaseLowerJsonStringEnumConverter))]
         public DeliveryType? DeliveryType { get; init; }
     }
 }

--- a/Kulipa.Sdk/Models/Requests/Cards/ReissueFromCard.cs
+++ b/Kulipa.Sdk/Models/Requests/Cards/ReissueFromCard.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Kulipa.Sdk.Models.Enums;
 
 namespace Kulipa.Sdk.Models.Requests.Cards
 {

--- a/Kulipa.Sdk/Models/Requests/Cards/ReissueFromCard.cs
+++ b/Kulipa.Sdk/Models/Requests/Cards/ReissueFromCard.cs
@@ -20,7 +20,6 @@ namespace Kulipa.Sdk.Models.Requests.Cards
         /// </summary>
         [Required]
         [JsonPropertyName("reason")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public required ReissueReason Reason { get; init; }
     }
 }

--- a/Kulipa.Sdk/Models/Requests/Users/UserWallet.cs
+++ b/Kulipa.Sdk/Models/Requests/Users/UserWallet.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Kulipa.Sdk.JsonConverters;
 using Kulipa.Sdk.Models.Enums;
 
 namespace Kulipa.Sdk.Models.Requests.Users
@@ -14,6 +15,7 @@ namespace Kulipa.Sdk.Models.Requests.Users
         /// </summary>
         [Required]
         [JsonPropertyName("blockchain")]
+        [JsonConverter(typeof(KebabCaseLowerJsonStringEnumConverter))]
         public required BlockchainNetwork Blockchain { get; init; }
 
         /// <summary>

--- a/Kulipa.Sdk/Models/Requests/Wallets/CreateWalletRequest.cs
+++ b/Kulipa.Sdk/Models/Requests/Wallets/CreateWalletRequest.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Kulipa.Sdk.JsonConverters;
 using Kulipa.Sdk.Models.Enums;
 
 namespace Kulipa.Sdk.Models.Requests.Wallets
@@ -29,7 +30,7 @@ namespace Kulipa.Sdk.Models.Requests.Wallets
         /// </summary>
         [Required]
         [JsonPropertyName("blockchain")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonConverter(typeof(KebabCaseLowerJsonStringEnumConverter))]
         public required BlockchainNetwork Blockchain { get; init; }
 
         /// <summary>

--- a/Kulipa.Sdk/Models/Responses/CardPayments/CardPayment.cs
+++ b/Kulipa.Sdk/Models/Responses/CardPayments/CardPayment.cs
@@ -18,21 +18,18 @@ namespace Kulipa.Sdk.Models.Responses.CardPayments
         ///     The type of payment transaction (payment or refund).
         /// </summary>
         [JsonPropertyName("type")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardPaymentType Type { get; init; }
 
         /// <summary>
         ///     The status of the payment during its lifecycle.
         /// </summary>
         [JsonPropertyName("status")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardPaymentStatus Status { get; init; }
 
         /// <summary>
         ///     In case the payment is rejected, this would supply a reason for the rejection.
         /// </summary>
         [JsonPropertyName("declineReason")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardPaymentDeclineReason DeclineReason { get; init; }
 
         /// <summary>

--- a/Kulipa.Sdk/Models/Responses/Cards/Card.cs
+++ b/Kulipa.Sdk/Models/Responses/Cards/Card.cs
@@ -48,7 +48,7 @@ namespace Kulipa.Sdk.Models.Responses.Cards
         ///     Card type.
         /// </summary>
         [JsonPropertyName("type")]
-        public CardFormat Format { get; init; }
+        public CardType Type { get; init; }
 
         /// <summary>
         ///     Card status.

--- a/Kulipa.Sdk/Models/Responses/Cards/Card.cs
+++ b/Kulipa.Sdk/Models/Responses/Cards/Card.cs
@@ -48,14 +48,12 @@ namespace Kulipa.Sdk.Models.Responses.Cards
         ///     Card type.
         /// </summary>
         [JsonPropertyName("type")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardFormat Format { get; init; }
 
         /// <summary>
         ///     Card status.
         /// </summary>
         [JsonPropertyName("status")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardStatus Status { get; init; }
 
         /// <summary>
@@ -98,14 +96,12 @@ namespace Kulipa.Sdk.Models.Responses.Cards
         ///     Who froze the card (only present when status is "frozen").
         /// </summary>
         [JsonPropertyName("frozenBy")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public FrozenBy? FrozenBy { get; init; }
 
         /// <summary>
         ///     Card tier.
         /// </summary>
         [JsonPropertyName("tier")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public CardTier Tier { get; init; }
     }
 }

--- a/Kulipa.Sdk/Models/Responses/Users/User.cs
+++ b/Kulipa.Sdk/Models/Responses/Users/User.cs
@@ -18,7 +18,6 @@ namespace Kulipa.Sdk.Models.Responses.Users
         ///     User status.
         /// </summary>
         [JsonPropertyName("status")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public UserStatus Status { get; init; }
 
         /// <summary>

--- a/Kulipa.Sdk/Models/Responses/Wallets/TopUp.cs
+++ b/Kulipa.Sdk/Models/Responses/Wallets/TopUp.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Kulipa.Sdk.JsonConverters;
 using Kulipa.Sdk.Models.Enums;
 
 namespace Kulipa.Sdk.Models.Responses.Wallets
@@ -42,6 +43,7 @@ namespace Kulipa.Sdk.Models.Responses.Wallets
         ///     A blockchain on which the wallet is deployed.
         /// </summary>
         [JsonPropertyName("blockchain")]
+        [JsonConverter(typeof(KebabCaseLowerJsonStringEnumConverter))]
         public BlockchainNetwork Blockchain { get; init; }
 
         /// <summary>

--- a/Kulipa.Sdk/Models/Responses/Wallets/Wallet.cs
+++ b/Kulipa.Sdk/Models/Responses/Wallets/Wallet.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Kulipa.Sdk.JsonConverters;
 using Kulipa.Sdk.Models.Enums;
 
 namespace Kulipa.Sdk.Models.Responses.Wallets
@@ -30,7 +31,6 @@ namespace Kulipa.Sdk.Models.Responses.Wallets
         ///     Status of the wallet.
         /// </summary>
         [JsonPropertyName("status")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public WalletStatus Status { get; init; }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Kulipa.Sdk.Models.Responses.Wallets
         ///     A blockchain on which a wallet is deployed.
         /// </summary>
         [JsonPropertyName("blockchain")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonConverter(typeof(KebabCaseLowerJsonStringEnumConverter))]
         public BlockchainNetwork Blockchain { get; init; }
 
         /// <summary>

--- a/Kulipa.Sdk/Models/Responses/Wallets/Withdrawal.cs
+++ b/Kulipa.Sdk/Models/Responses/Wallets/Withdrawal.cs
@@ -30,7 +30,6 @@ namespace Kulipa.Sdk.Models.Responses.Wallets
         ///     Current status of the withdrawal transaction.
         /// </summary>
         [JsonPropertyName("status")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public WithdrawalStatus Status { get; init; }
 
         /// <summary>

--- a/Kulipa.Sdk/Resources/BaseResource.cs
+++ b/Kulipa.Sdk/Resources/BaseResource.cs
@@ -30,7 +30,7 @@ namespace Kulipa.Sdk.Resources
             _jsonOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             };
         }

--- a/Kulipa.Sdk/Resources/BaseResource.cs
+++ b/Kulipa.Sdk/Resources/BaseResource.cs
@@ -2,6 +2,7 @@ using System.Collections.Specialized;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Web;
 using Kulipa.Sdk.Exceptions;
 using Kulipa.Sdk.Models.Requests.Common;
@@ -29,7 +30,8 @@ namespace Kulipa.Sdk.Resources
             _jsonOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true
+                PropertyNameCaseInsensitive = true,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             };
         }
 


### PR DESCRIPTION
### Changes:
- Removed `JsonPropertyName` attributes from enums as they don't add any value at all
- Removed individual `JsonStringEnumConverter` attributes and applied global `JsonNamingPolicy.CamelCase` rule
- Introduced `KebabCaseLowerJsonStringEnumConverter` and `SnakeCaseLowerJsonStringEnumConverter` for special cases.